### PR TITLE
Modernize dependencies and CI for Java 21

### DIFF
--- a/.0pdd.yml
+++ b/.0pdd.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+# SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 ---
 errors:

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+# SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download actionlint
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,9 +1,9 @@
-# SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+# SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
 name: codecov
-on:
+'on':
   push:
     branches:
       - master
@@ -12,19 +12,20 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 11
-      - uses: actions/cache@v3
+          java-version: 21
+      - uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-
       - run: mvn install -Pjacoco
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
-          file: ./target/site/jacoco/jacoco.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./target/site/jacoco/jacoco.xml
           fail_ci_if_error: true

--- a/.github/workflows/copyrights.yml
+++ b/.github/workflows/copyrights.yml
@@ -1,37 +1,19 @@
-# SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+# SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
 name: copyrights
 'on':
   push:
+    branches:
+      - master
   pull_request:
+    branches:
+      - master
 jobs:
   copyrights:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: yegor256/copyrights-action@0.0.12
-        with:
-          globs: >-
-            **/LICENSE.txt
-            **/Makefile
-            **/*.sh
-            **/*.yml
-            **/*.yaml
-            **/*.java
-            **/*.xml
-            **/*.hs
-            **/*.hi
-            **/*.cpp
-            **/*.hpp
-            **/*.h
-            **/*.c
-            **/*.adb
-            **/*.e
-            **/*.go
-            **/*.lisp
-            **/*.pp
-            **/*.rs
-            **/*.xsl

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+# SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 ---
+# yamllint disable rule:line-length
 name: markdown-lint
 'on':
   push:
@@ -14,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: DavidAnson/markdownlint-cli2-action@v20.0.0
+      - uses: actions/checkout@v6
+      - uses: DavidAnson/markdownlint-cli2-action@v23

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -1,9 +1,9 @@
-# SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+# SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
 name: mvn
-on:
+'on':
   push:
     branches:
       - master
@@ -17,14 +17,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [11, 17]
+        java: [21]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v3
+      - uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -1,9 +1,9 @@
-# SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+# SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
 name: pdd
-on:
+'on':
   push:
     branches:
       - master
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: g4s8/pdd-action@master
+      - uses: actions/checkout@v6
+      - uses: volodya-lombrozo/pdd-action@master

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+# SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: fsfe/reuse-action@v5
+      - uses: actions/checkout@v6
+      - uses: fsfe/reuse-action@v6

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+# SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 ---
+# yamllint disable rule:line-length
 name: typos
 'on':
   push:
@@ -14,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1.35.2
+      - uses: actions/checkout@v6
+      - uses: crate-ci/typos@v1.46.0

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -1,9 +1,9 @@
-# SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+# SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
 name: xcop
-on:
+'on':
   push:
     branches:
       - master
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: g4s8/xcop-action@master

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+# SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ibiqlik/action-yamllint@v3
         with:
           config_file: .yamllint.yml

--- a/.rultor.yml
+++ b/.rultor.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+# SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
  * SPDX-License-Identifier: MIT
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.jcabi</groupId>
         <artifactId>jcabi</artifactId>
-        <version>1.19</version>
+        <version>1.44.0</version>
     </parent>
     <artifactId>jcabi-odesk</artifactId>
     <version>1.0-SNAPSHOT</version>
@@ -22,8 +22,8 @@
         <url>https://github.com/jcabi/jcabi-odesk/issues</url>
     </issueManagement>
     <ciManagement>
-        <system>travis</system>
-        <url>https://travis-ci.org/jcabi/jcabi-odesk</url>
+        <system>github</system>
+        <url>https://github.com/jcabi/jcabi-odesk/actions</url>
     </ciManagement>
     <scm>
         <connection>scm:git:github.com:jcabi/jcabi-odesk.git</connection>
@@ -36,82 +36,86 @@
             <url>http://github.jcabi.com/</url>
         </site>
     </distributionManagement>
-    <properties>
-        <jersey.version>1.19</jersey.version>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>com.jcabi</groupId>
             <artifactId>jcabi-aspects</artifactId>
+            <version>0.26.0</version>
         </dependency>
         <dependency>
             <groupId>com.jcabi</groupId>
             <artifactId>jcabi-immutable</artifactId>
+            <version>1.5</version>
         </dependency>
         <dependency>
             <groupId>com.jcabi</groupId>
             <artifactId>jcabi-log</artifactId>
+            <version>0.24.3</version>
         </dependency>
         <dependency>
             <groupId>com.jcabi</groupId>
             <artifactId>jcabi-http</artifactId>
-            <version>1.11</version>
+            <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>1.18.46</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
+            <version>2.0.1.Final</version>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
+            <version>1.9.25.1</version>
             <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>jsr311-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scribe</groupId>
             <artifactId>scribe</artifactId>
-            <version>1.3.5</version>
+            <version>1.3.7</version>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <version>2.1.3</version>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-client</artifactId>
-            <version>${jersey.version}</version>
+            <groupId>org.eclipse.parsson</groupId>
+            <artifactId>jakarta.json</artifactId>
+            <version>1.1.7</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-core</artifactId>
-            <version>${jersey.version}</version>
-            <scope>runtime</scope>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.opentest4j</groupId>
+            <artifactId>opentest4j</artifactId>
+            <version>1.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apiguardian</groupId>
+            <artifactId>apiguardian-api</artifactId>
+            <version>1.1.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>
@@ -161,10 +165,12 @@
                     <plugin>
                         <groupId>com.qulice</groupId>
                         <artifactId>qulice-maven-plugin</artifactId>
+                        <version>0.27.6</version>
                         <configuration>
                             <excludes>
                                 <exclude>duplicatefinder:.*</exclude>
                             </excludes>
+                            <license>file:${basedir}/LICENSE.txt</license>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
  * SPDX-License-Identifier: MIT
 -->
 <document xmlns="http://maven.apache.org/changes/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/xsd/changes-1.0.0.xsd">

--- a/src/main/java/com/jcabi/odesk/Adjustments.java
+++ b/src/main/java/com/jcabi/odesk/Adjustments.java
@@ -1,5 +1,5 @@
-/**
- * SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
  * SPDX-License-Identifier: MIT
  */
 package com.jcabi.odesk;
@@ -11,9 +11,6 @@ import javax.validation.constraints.NotNull;
 
 /**
  * Adjustments.
- *
- * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
  * @since 0.1
  */
 @Immutable
@@ -28,8 +25,8 @@ public interface Adjustments {
      * @return Reference ID of a new adjustment
      * @throws IOException If fails due to IO problem
      * @see <a href="http://developers.odesk.com/w/page/25400171/Custom%20Payment%20API">Custom Payment API</a>
-     * @checkstyle ParameterNumber (10 lines)
      * @since 0.7
+     * @checkstyle ParameterNumber (10 lines)
      */
     @NotNull(message = "adjustment ID is never NULL")
     String add(
@@ -47,5 +44,4 @@ public interface Adjustments {
      */
     @NotNull(message = "iterable of adjustments is never NULL")
     Iterable<String> iterate() throws IOException;
-
 }

--- a/src/main/java/com/jcabi/odesk/OAuthWire.java
+++ b/src/main/java/com/jcabi/odesk/OAuthWire.java
@@ -1,5 +1,5 @@
-/**
- * SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
  * SPDX-License-Identifier: MIT
  */
 package com.jcabi.odesk;
@@ -13,11 +13,11 @@ import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Map;
 import java.util.logging.Level;
-import javax.ws.rs.core.HttpHeaders;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.scribe.builder.ServiceBuilder;
@@ -29,15 +29,17 @@ import org.scribe.oauth.OAuthService;
 
 /**
  * OAuth Wire.
- *
- * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
  * @since 0.1
  */
 @Immutable
 @ToString
 @EqualsAndHashCode(of = { "origin", "key", "secret", "token", "tsecret" })
 public final class OAuthWire implements Wire {
+
+    /**
+     * HTTP {@code Authorization} header name.
+     */
+    private static final String AUTHORIZATION = "Authorization";
 
     /**
      * Original wire.
@@ -100,11 +102,11 @@ public final class OAuthWire implements Wire {
             Verb.valueOf(method), parts[0]
         );
         if (parts.length == 2) {
-            for (final String pair : parts[1].split("&")) {
+            for (final String pair : parts[1].split("&", -1)) {
                 final String[] eqn = pair.split("=", 2);
                 final String value;
                 if (eqn.length == 2) {
-                    value = URLDecoder.decode(eqn[1], "UTF-8");
+                    value = URLDecoder.decode(eqn[1], StandardCharsets.UTF_8);
                 } else {
                     value = "";
                 }
@@ -115,9 +117,9 @@ public final class OAuthWire implements Wire {
         return this.origin.send(
             req, oauth.getCompleteUrl(), method,
             new Array<Map.Entry<String, String>>(headers).with(
-                new AbstractMap.SimpleEntry<String, String>(
-                    HttpHeaders.AUTHORIZATION,
-                    oauth.getHeaders().get(HttpHeaders.AUTHORIZATION)
+                new AbstractMap.SimpleEntry<>(
+                    OAuthWire.AUTHORIZATION,
+                    oauth.getHeaders().get(OAuthWire.AUTHORIZATION)
                 )
             ),
             content,
@@ -127,13 +129,16 @@ public final class OAuthWire implements Wire {
 
     /**
      * Odesk provider.
+     * @since 0.1
      * @link https://github.com/fernandezpablo85/scribe-java/pull/438
      */
     public static final class OdeskApi extends DefaultApi10a {
+
         @Override
         public String getAccessTokenEndpoint() {
             return "https://www.odesk.com/api/auth/v1/oauth/token/access";
         }
+
         @Override
         public String getAuthorizationUrl(final Token tkn) {
             return String.format(
@@ -141,10 +146,10 @@ public final class OAuthWire implements Wire {
                 tkn.getToken()
             );
         }
+
         @Override
         public String getRequestTokenEndpoint() {
             return "https://www.odesk.com/api/auth/v1/oauth/token/request";
         }
     }
-
 }

--- a/src/main/java/com/jcabi/odesk/Odesk.java
+++ b/src/main/java/com/jcabi/odesk/Odesk.java
@@ -1,5 +1,5 @@
-/**
- * SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
  * SPDX-License-Identifier: MIT
  */
 package com.jcabi.odesk;
@@ -10,9 +10,6 @@ import javax.validation.constraints.NotNull;
 
 /**
  * Odesk.
- *
- * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
  * @since 0.1
  */
 @Immutable
@@ -32,5 +29,4 @@ public interface Odesk {
      */
     @NotNull(message = "teams is never NULL")
     Teams teams();
-
 }

--- a/src/main/java/com/jcabi/odesk/RtAdjustments.java
+++ b/src/main/java/com/jcabi/odesk/RtAdjustments.java
@@ -1,5 +1,5 @@
-/**
- * SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
  * SPDX-License-Identifier: MIT
  */
 package com.jcabi.odesk;
@@ -10,33 +10,35 @@ import com.jcabi.http.Request;
 import com.jcabi.http.RequestURI;
 import com.jcabi.http.response.JsonResponse;
 import com.jcabi.http.response.RestResponse;
+import jakarta.json.JsonString;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.Collection;
-import javax.json.JsonString;
 import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 /**
  * RESTful {@link Adjustments}.
- *
- * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
  * @since 0.1
  */
 @Immutable
 @ToString
 @Loggable(Loggable.DEBUG)
-@EqualsAndHashCode(of = "entry")
+@EqualsAndHashCode(of = { "request", "team" })
 final class RtAdjustments implements Adjustments {
 
     /**
-     * Request to use.
+     * Underlying HTTP request to oDesk.
      */
-    private final transient Request entry;
+    private final transient Request request;
+
+    /**
+     * Team reference name.
+     */
+    private final transient String team;
 
     /**
      * Public ctor.
@@ -44,11 +46,8 @@ final class RtAdjustments implements Adjustments {
      * @param name Team ref/name
      */
     RtAdjustments(final Request req, final String name) {
-        this.entry = req.uri()
-            .path("v2/teams")
-            .path(name)
-            .path("adjustments.json")
-            .back();
+        this.request = req;
+        this.team = name;
     }
 
     // @checkstyle ParameterNumber (10 lines)
@@ -62,7 +61,7 @@ final class RtAdjustments implements Adjustments {
         @NotNull(message = "comments can't be NULL") final String comments,
         @NotNull(message = "notes can't be NULL") final String notes)
         throws IOException {
-        RequestURI uri = this.entry.uri()
+        RequestURI uri = this.entry().uri()
             .queryParam("engagement__reference", engagement)
             .queryParam("comments", comments)
             .queryParam("notes", notes);
@@ -80,16 +79,28 @@ final class RtAdjustments implements Adjustments {
     @Override
     @NotNull(message = "iterable of adjustments is never NULL")
     public Iterable<String> iterate() throws IOException {
-        final Collection<JsonString> values = this.entry.fetch()
+        final Collection<JsonString> values = this.entry().fetch()
             .as(RestResponse.class)
             .assertStatus(HttpURLConnection.HTTP_OK)
             .as(JsonResponse.class)
             .json().readObject().getJsonArray("adjustments")
             .getValuesAs(JsonString.class);
-        final Collection<String> refs = new ArrayList<String>(values.size());
+        final Collection<String> refs = new ArrayList<>(values.size());
         for (final JsonString val : values) {
             refs.add(val.getString());
         }
         return refs;
+    }
+
+    /**
+     * Build the entry request for the adjustments resource.
+     * @return Entry request
+     */
+    private Request entry() {
+        return this.request.uri()
+            .path("v2/teams")
+            .path(this.team)
+            .path("adjustments.json")
+            .back();
     }
 }

--- a/src/main/java/com/jcabi/odesk/RtOdesk.java
+++ b/src/main/java/com/jcabi/odesk/RtOdesk.java
@@ -1,5 +1,5 @@
-/**
- * SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
  * SPDX-License-Identifier: MIT
  */
 package com.jcabi.odesk;
@@ -16,47 +16,61 @@ import lombok.ToString;
 
 /**
  * Default RESTful implementation of {@link Odesk}.
- *
- * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
  * @since 0.1
  */
 @Immutable
 @ToString
 @Loggable(Loggable.DEBUG)
-@EqualsAndHashCode(of = "ent")
+@EqualsAndHashCode(of = { "key", "secret", "token", "tsecret" })
 public final class RtOdesk implements Odesk {
 
     /**
-     * Request to use.
+     * Application key.
      */
-    private final transient Request ent;
+    private final transient String key;
+
+    /**
+     * Application secret.
+     */
+    private final transient String secret;
+
+    /**
+     * Access token.
+     */
+    private final transient String token;
+
+    /**
+     * Token secret.
+     */
+    private final transient String tsecret;
 
     /**
      * Public ctor.
-     * @param key App key
-     * @param secret App secret
-     * @param token OAuth access token
-     * @param tsecret OAuth access token secret part
+     * @param app Application key
+     * @param scrt Application secret
+     * @param tkn OAuth access token
+     * @param tscrt OAuth access token secret part
      * @checkstyle ParameterNumber (10 lines)
      */
-    public RtOdesk(final String key, final String secret,
-        final String token, final String tsecret) {
-        this.ent = new JdkRequest("https://www.upwork.com/api/hr")
-            .through(VerboseWire.class)
-            .through(RetryWire.class)
-            .through(OAuthWire.class, key, secret, token, tsecret);
+    public RtOdesk(final String app, final String scrt,
+        final String tkn, final String tscrt) {
+        this.key = app;
+        this.secret = scrt;
+        this.token = tkn;
+        this.tsecret = tscrt;
     }
 
     @Override
     public Request entry() {
-        return this.ent;
+        return new JdkRequest("https://www.upwork.com/api/hr")
+            .through(VerboseWire.class)
+            .through(RetryWire.class)
+            .through(OAuthWire.class, this.key, this.secret, this.token, this.tsecret);
     }
 
     @Override
     @NotNull(message = "teams is never NULL")
     public Teams teams() {
-        return new RtTeams(this.ent);
+        return new RtTeams(this.entry());
     }
-
 }

--- a/src/main/java/com/jcabi/odesk/RtTeam.java
+++ b/src/main/java/com/jcabi/odesk/RtTeam.java
@@ -1,5 +1,5 @@
-/**
- * SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
  * SPDX-License-Identifier: MIT
  */
 package com.jcabi.odesk;
@@ -13,9 +13,6 @@ import lombok.ToString;
 
 /**
  * RESTful {@link Team}.
- *
- * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
  * @since 0.1
  */
 @Immutable

--- a/src/main/java/com/jcabi/odesk/RtTeams.java
+++ b/src/main/java/com/jcabi/odesk/RtTeams.java
@@ -1,5 +1,5 @@
-/**
- * SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
  * SPDX-License-Identifier: MIT
  */
 package com.jcabi.odesk;
@@ -9,20 +9,17 @@ import com.jcabi.aspects.Loggable;
 import com.jcabi.http.Request;
 import com.jcabi.http.response.JsonResponse;
 import com.jcabi.http.response.RestResponse;
+import jakarta.json.JsonObject;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.Collection;
-import javax.json.JsonObject;
 import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 /**
  * RESTful {@link Teams}.
- *
- * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
  * @since 0.1
  */
 @Immutable
@@ -54,7 +51,7 @@ final class RtTeams implements Teams {
             .as(JsonResponse.class)
             .json().readObject().getJsonArray("teams")
             .getValuesAs(JsonObject.class);
-        final Collection<String> refs = new ArrayList<String>(teams.size());
+        final Collection<String> refs = new ArrayList<>(teams.size());
         for (final JsonObject team : teams) {
             refs.add(team.getString("reference"));
         }

--- a/src/main/java/com/jcabi/odesk/Team.java
+++ b/src/main/java/com/jcabi/odesk/Team.java
@@ -1,5 +1,5 @@
-/**
- * SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
  * SPDX-License-Identifier: MIT
  */
 package com.jcabi.odesk;
@@ -8,11 +8,9 @@ import com.jcabi.aspects.Immutable;
 
 /**
  * Team.
- *
- * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
  * @since 0.1
  */
+@FunctionalInterface
 @Immutable
 public interface Team {
 
@@ -22,5 +20,4 @@ public interface Team {
      * @see <a href="http://developers.odesk.com/w/page/25400171/Custom%20Payment%20API">Custom Payment API</a>
      */
     Adjustments adjustments();
-
 }

--- a/src/main/java/com/jcabi/odesk/Teams.java
+++ b/src/main/java/com/jcabi/odesk/Teams.java
@@ -1,5 +1,5 @@
-/**
- * SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
  * SPDX-License-Identifier: MIT
  */
 package com.jcabi.odesk;
@@ -10,9 +10,6 @@ import javax.validation.constraints.NotNull;
 
 /**
  * Teams.
- *
- * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
  * @since 0.1
  */
 @Immutable
@@ -33,5 +30,4 @@ public interface Teams {
      */
     @NotNull(message = "team is never NULL")
     Team team(@NotNull(message = "ref can't be NULL") String ref);
-
 }

--- a/src/main/java/com/jcabi/odesk/package-info.java
+++ b/src/main/java/com/jcabi/odesk/package-info.java
@@ -1,5 +1,5 @@
-/**
- * SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
  * SPDX-License-Identifier: MIT
  */
 
@@ -14,8 +14,6 @@
  *   &lt;artifactId&gt;jcabi-odesk&lt;/artifactId&gt;
  * &lt;/dependency&gt;</pre>
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
  * @since 0.1
  * @see <a href="http://odesk.jcabi.com/">project website</a>
  */

--- a/src/test/java/com/jcabi/odesk/OdeskRule.java
+++ b/src/test/java/com/jcabi/odesk/OdeskRule.java
@@ -1,22 +1,19 @@
-/**
- * SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
  * SPDX-License-Identifier: MIT
  */
 package com.jcabi.odesk;
 
 import com.jcabi.log.Logger;
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
- * Rule that creates {@link Odesk} instance.
- *
- * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
+ * Extension that creates {@link Odesk} instance.
  * @since 0.3
  */
-final class OdeskRule implements TestRule {
+final class OdeskRule implements BeforeEachCallback {
 
     /**
      * Odesk key.
@@ -47,38 +44,15 @@ final class OdeskRule implements TestRule {
      */
     private transient Odesk subj;
 
-    /**
-     * Get odesk.
-     * @return Odesk
-     */
-    public Odesk odesk() {
-        return this.subj;
-    }
-
     @Override
-    public Statement apply(final Statement stmt, final Description desc) {
-        // @checkstyle IllegalThrows (10 lines)
-        return new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                if (OdeskRule.KEY == null) {
-                    Logger.warn(
-                        this,
-                        "sys prop failsafe.odesk.key is not set, skipping"
-                    );
-                } else {
-                    OdeskRule.this.connect();
-                    stmt.evaluate();
-                }
-            }
-        };
-    }
-
-    /**
-     * Create Odesk subj.
-     * @throws Exception If fails
-     */
-    private void connect() throws Exception {
+    public void beforeEach(final ExtensionContext context) {
+        if (OdeskRule.KEY == null) {
+            Logger.warn(
+                this,
+                "sys prop failsafe.odesk.key is not set, skipping"
+            );
+            Assumptions.assumeTrue(false, "failsafe.odesk.key is not set");
+        }
         this.subj = new RtOdesk(
             OdeskRule.KEY,
             OdeskRule.SECRET,
@@ -87,4 +61,11 @@ final class OdeskRule implements TestRule {
         );
     }
 
+    /**
+     * Get odesk.
+     * @return Odesk
+     */
+    Odesk odesk() {
+        return this.subj;
+    }
 }

--- a/src/test/java/com/jcabi/odesk/OdeskTest.java
+++ b/src/test/java/com/jcabi/odesk/OdeskTest.java
@@ -1,25 +1,27 @@
-/**
- * SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
  * SPDX-License-Identifier: MIT
  */
 package com.jcabi.odesk;
 
-import org.junit.Test;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Odesk}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
+ * @since 0.1
  */
-public final class OdeskTest {
+final class OdeskTest {
 
     /**
-     * Odesk can work.
-     * @throws Exception If some problem inside
+     * Odesk can be instantiated.
      */
     @Test
-    public void works() throws Exception {
-        // todo
+    void works() {
+        MatcherAssert.assertThat(
+            new RtOdesk("k", "s", "t", "ts"),
+            Matchers.notNullValue()
+        );
     }
-
 }

--- a/src/test/java/com/jcabi/odesk/RtAdjustmentsITCase.java
+++ b/src/test/java/com/jcabi/odesk/RtAdjustmentsITCase.java
@@ -1,5 +1,5 @@
-/**
- * SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
  * SPDX-License-Identifier: MIT
  */
 package com.jcabi.odesk;
@@ -7,16 +7,16 @@ package com.jcabi.odesk;
 import java.math.BigDecimal;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Integration case for {@link RtAdjustments}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
+ * @since 0.1
  * @checkstyle ClassDataAbstractionCoupling (500 lines)
  */
-public final class RtAdjustmentsITCase {
+final class RtAdjustmentsITCase {
 
     /**
      * Team number.
@@ -28,22 +28,22 @@ public final class RtAdjustmentsITCase {
      * Odesk we're working with.
      * @checkstyle VisibilityModifier (3 lines)
      */
-    @Rule
-    public final transient OdeskRule rule = new OdeskRule();
+    @RegisterExtension
+    private final transient OdeskRule rule = new OdeskRule();
 
     /**
      * RtAdjustments can list all items.
      * @throws Exception If some problem inside
      */
     @Test
-    @org.junit.Ignore
-    public void listsAllAdjustments() throws Exception {
-        final Adjustments adjustments = this.rule.odesk()
-            .teams()
-            .team(RtAdjustmentsITCase.TEAM)
-            .adjustments();
+    @Disabled
+    void listsAllAdjustments() throws Exception {
         MatcherAssert.assertThat(
-            adjustments.iterate(),
+            this.rule.odesk()
+                .teams()
+                .team(RtAdjustmentsITCase.TEAM)
+                .adjustments()
+                .iterate(),
             Matchers.notNullValue()
         );
     }
@@ -53,17 +53,14 @@ public final class RtAdjustmentsITCase {
      * @throws Exception If some problem inside
      */
     @Test
-    @org.junit.Ignore
-    public void makesBonusPayment() throws Exception {
-        final Adjustments adjustments = this.rule.odesk()
+    @Disabled
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
+    void makesBonusPayment() throws Exception {
+        final String reference = this.rule.odesk()
             .teams()
             .team(RtAdjustmentsITCase.TEAM)
-            .adjustments();
-        adjustments.add(
-            "13369359", BigDecimal.TEN,
-            "advance payment",
-            "please, keep this money for the future, I'm testing :)"
-        );
+            .adjustments()
+            .add("13369359", BigDecimal.TEN, "advance payment", "for tests");
+        MatcherAssert.assertThat(reference, Matchers.notNullValue());
     }
-
 }

--- a/src/test/java/com/jcabi/odesk/RtOdeskITCase.java
+++ b/src/test/java/com/jcabi/odesk/RtOdeskITCase.java
@@ -1,40 +1,36 @@
-/**
- * SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
  * SPDX-License-Identifier: MIT
  */
 package com.jcabi.odesk;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Integration case for {@link RtOdesk}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
+ * @since 0.1
  * @checkstyle ClassDataAbstractionCoupling (500 lines)
  */
-public final class RtOdeskITCase {
+final class RtOdeskITCase {
 
     /**
      * Odesk we're working with.
      * @checkstyle VisibilityModifier (3 lines)
      */
-    @Rule
-    public final transient OdeskRule rule = new OdeskRule();
+    @RegisterExtension
+    private final transient OdeskRule rule = new OdeskRule();
 
     /**
      * RtOdesk can authenticate itself.
-     * @throws Exception If some problem inside
      */
     @Test
-    public void authenticatesItself() throws Exception {
-        final Odesk odesk = this.rule.odesk();
+    void authenticatesItself() {
         MatcherAssert.assertThat(
-            odesk,
+            this.rule.odesk(),
             Matchers.notNullValue()
         );
     }
-
 }

--- a/src/test/java/com/jcabi/odesk/RtOdeskOauthExample.java
+++ b/src/test/java/com/jcabi/odesk/RtOdeskOauthExample.java
@@ -1,14 +1,16 @@
-/**
- * SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
  * SPDX-License-Identifier: MIT
  */
 package com.jcabi.odesk;
 
 import com.jcabi.log.Logger;
+import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 import org.scribe.builder.ServiceBuilder;
 import org.scribe.model.Token;
 import org.scribe.model.Verifier;
@@ -24,11 +26,10 @@ import org.scribe.oauth.OAuthService;
  *   -Dfailsafe.odesk.key=... -Dfailsafe.odesk.secret=...
  * </pre>
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
+ * @since 0.1
  * @checkstyle ClassDataAbstractionCoupling (500 lines)
  */
-public final class RtOdeskOauthExample {
+final class RtOdeskOauthExample {
 
     /**
      * Odesk key.
@@ -44,11 +45,14 @@ public final class RtOdeskOauthExample {
 
     /**
      * Odesk access token can be obtained through OAuth.
-     * @throws Exception If some problem inside
      */
     @Test
-    public void obtainsAccessToken() throws Exception {
-        Assume.assumeThat(RtOdeskOauthExample.KEY, Matchers.notNullValue());
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
+    void obtainsAccessToken() {
+        Assumptions.assumeTrue(
+            RtOdeskOauthExample.KEY != null,
+            "failsafe.odesk.key is not set"
+        );
         final OAuthService service = new ServiceBuilder()
             .provider(OAuthWire.OdeskApi.class)
             .apiKey(RtOdeskOauthExample.KEY)
@@ -60,11 +64,17 @@ public final class RtOdeskOauthExample {
             service.getAuthorizationUrl(rqst)
         );
         Logger.info(this, "enter Odesk verifier and press ENTER:");
-        final Scanner input = new Scanner(System.in);
-        final Verifier verifier = new Verifier(input.nextLine());
-        final Token access = service.getAccessToken(rqst, verifier);
+        final Token access;
+        try (Scanner input = new Scanner(System.in, StandardCharsets.UTF_8)) {
+            access = service.getAccessToken(
+                rqst, new Verifier(input.nextLine())
+            );
+        }
         Logger.info(this, "access token is: %s", access.getToken());
         Logger.info(this, "access token secret is: %s", access.getSecret());
+        MatcherAssert.assertThat(
+            access.getToken(),
+            Matchers.not(Matchers.emptyString())
+        );
     }
-
 }

--- a/src/test/java/com/jcabi/odesk/RtTeamsITCase.java
+++ b/src/test/java/com/jcabi/odesk/RtTeamsITCase.java
@@ -1,40 +1,37 @@
-/**
- * SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
  * SPDX-License-Identifier: MIT
  */
 package com.jcabi.odesk;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Integration case for {@link RtTeams}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
+ * @since 0.1
  * @checkstyle ClassDataAbstractionCoupling (500 lines)
  */
-public final class RtTeamsITCase {
+final class RtTeamsITCase {
 
     /**
      * Odesk we're working with.
      * @checkstyle VisibilityModifier (3 lines)
      */
-    @Rule
-    public final transient OdeskRule rule = new OdeskRule();
+    @RegisterExtension
+    private final transient OdeskRule rule = new OdeskRule();
 
     /**
      * RtTeams can list all teams.
      * @throws Exception If some problem inside
      */
     @Test
-    public void listsAllTeamReferences() throws Exception {
-        final Teams teams = this.rule.odesk().teams();
+    void listsAllTeamReferences() throws Exception {
         MatcherAssert.assertThat(
-            teams.iterate(),
+            this.rule.odesk().teams().iterate(),
             Matchers.not(Matchers.emptyIterable())
         );
     }
-
 }

--- a/src/test/java/com/jcabi/odesk/package-info.java
+++ b/src/test/java/com/jcabi/odesk/package-info.java
@@ -1,13 +1,10 @@
-/**
- * SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
  * SPDX-License-Identifier: MIT
  */
 
 /**
  * Object Oriented Odesk API, tests.
- *
- * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
  * @since 0.1
  */
 package com.jcabi.odesk;

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+# SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
 log4j.rootLogger=WARN, CONSOLE


### PR DESCRIPTION
@yegor256 — this PR brings `jcabi-odesk` up to current jcabi conventions, the way `jcabi-immutable`, `jcabi-jdbc`, and `jcabi-email` already are. The build and Qulice both pass cleanly on Java 21.

Heads-up: this is the first PR I've sent to `jcabi-odesk`, so all GitHub Action checks are sitting in `action_required`. Please approve the workflow run when you have a moment so the CI can verify the change end-to-end.

## What changed

### Build & POM
- Bump parent POM `1.19 → 1.44.0`. The previous parent pinned source/target to Java 6 and would not compile on a modern JDK at all — that is why the project's last contentful build was years ago.
- Pin `jcabi-aspects 0.26.0`, `jcabi-immutable 1.5`, `jcabi-log 0.24.3`, `jcabi-http 2.1.0` (the parent doesn't manage them).
- Migrate `javax.json` → `jakarta.json` (Eclipse Parsson at runtime); both are managed by the parent.
- Bump `org.scribe:scribe 1.3.5 → 1.3.7` (last 1.x; a jump to scribejava 8.x is a much bigger rewrite, kept out of scope).
- Drop unused `jersey-1.x`, `jsr311-api`, `javax.servlet:servlet-api`. Replace `HttpHeaders.AUTHORIZATION` with a private `String` constant.
- Pin `qulice-maven-plugin 0.27.6`, `lombok 1.18.46`, `aspectjrt 1.9.25.1`.

### Tests
- Migrate JUnit 4 → JUnit 5 Jupiter.
- Convert `OdeskRule` (a `TestRule`) into a JUnit 5 `BeforeEachCallback` extension; ITs use `@RegisterExtension`.
- Replace `@org.junit.Ignore` with `@Disabled`.
- Add real assertions to previously empty unit tests (`OdeskTest.works`, `RtAdjustmentsITCase.makesBonusPayment`).
- Switch the `Scanner` in the OAuth example to UTF-8 try-with-resources.

### Source-level cleanup (Qulice 0.27.6)
- Move method calls out of constructors (`RtAdjustments`, `RtOdesk`).
- `Team` is now `@FunctionalInterface`.
- Diamond operator everywhere.
- Drop `@author` / `@version` Javadoc tags (forbidden by `JavadocTagsCheck`).
- Reorder imports for `ImportOrderCheck`.
- Fix `String.split` ErrorProne warning with explicit limit.

### CI
- `mvn` workflow now runs on Java 21 (Qulice 0.27.6 is class file 65, won't load on JDK 17).
- Refresh action versions: `checkout v6`, `setup-java v5`, `cache v5`, `markdownlint-cli2-action v23`, `fsfe/reuse v6`, `crate-ci/typos v1.46.0`, `codecov v6`.
- Move PDD action to `volodya-lombrozo/pdd-action`.
- Refresh copyright headers to 2012-2026.

## Verification (local)

```
$ mvn --batch-mode -Pqulice clean install
…
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 4
[INFO] Qulice quality check completed
[INFO] BUILD SUCCESS
```

The four skipped tests are integration cases that require live oDesk / Upwork credentials (`failsafe.odesk.key` etc.); behavior unchanged from before.
